### PR TITLE
Fix persistence

### DIFF
--- a/chart/microservice-vote/templates/basedeployment.yaml
+++ b/chart/microservice-vote/templates/basedeployment.yaml
@@ -57,10 +57,8 @@ spec:
               secretKeyRef:
                 name: cloudant-secret
                 key: dbPassword
-          - name: dbHost
-            value: $CLOUDANT_SERVICE_SERVICE_HOST
-          - name: dbPort
-            value: $CLOUDANT_SERVICE_SERVICE_PORT
+          - name: dbUrl
+            value: "http://{{ .Release.Name | trunc 46 | trimSuffix "-" }}-ibm-cloudant-dev"
           - name: USERNAME
             value: admin
           - name: PASSWORD
@@ -75,8 +73,6 @@ spec:
               secretKeyRef:
                 name: mb-truststore-password
                 key: password
-        command: ["/bin/sh","-c"]
-        args: ["if [ ! -z $dbPassword ]; then export dbUrl=http://$CLOUDANT_SERVICE_SERVICE_HOST:$CLOUDANT_SERVICE_SERVICE_PORT; exec /opt/ibm/wlp/bin/server run defaultServer; fi;"]
         volumeMounts:
         - name: keystore
           mountPath: /etc/wlp/config/keystore

--- a/chart/microservice-vote/templates/deployment.yaml
+++ b/chart/microservice-vote/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
                 name: cloudant-secret
                 key: dbPassword
           - name: dbUrl
-            value: "http://{{ .Chart.Name | trunc 46 | trimSuffix "-" }}-ibm-cloudant-dev"
+            value: "http://{{ .Release.Name | trunc 46 | trimSuffix "-" }}-ibm-cloudant-dev"
           - name: USERNAME
             value: admin
           - name: PASSWORD

--- a/chart/microservice-vote/templates/pv.yaml
+++ b/chart/microservice-vote/templates/pv.yaml
@@ -8,7 +8,7 @@ metadata:
     type: local
 spec:
   capacity:
-    storage: {{ index .Values "ibm-cloudant-dev" "databasePVC.size" }}
+    storage: {{ index .Values "ibm-cloudant-dev" "databasePVC" "size" }}
   accessModes:
     - ReadWriteOnce
   hostPath:

--- a/chart/microservice-vote/templates/pv.yaml
+++ b/chart/microservice-vote/templates/pv.yaml
@@ -1,4 +1,5 @@
-{{ if index .Values "ibm-cloudant-dev" "persistence.useDynamicProvisioning" }}
+{{ if index .Values "ibm-cloudant-dev" "persistence" "enabled" }}
+{{ if index .Values "ibm-cloudant-dev" "persistence" "useDynamicProvisioning" }}
 {{ else }}
 kind: PersistentVolume
 apiVersion: v1
@@ -14,4 +15,5 @@ spec:
   hostPath:
     path: "/var/cloudant"
 {{ end }}    
-
+{{ else }}
+{{ end }}


### PR DESCRIPTION
The former syntax was causing failures for others. I'm not quite sure if it's a difference in helm version behavior, or it was always failing.

Add the additional check for persistence.enabled so the PV is not created when persistence is disabled.

Jag needs to verify on minikube before blessing for acceptance.

